### PR TITLE
fixed opts/hash lookup for new pathFor syntax

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -18,14 +18,13 @@ UI.registerHelper('pathFor', function (routeName, options) {
 
     var opts;
 
-    if (typeof routeName == 'object') {
-        opts = routeName;
-        routeName = opts && opts.hash && opts.hash.route;
-    } else {
-        opts = options && options.hash
-    }
+    if (typeof routeName === 'object') {
+        opts = routeName.hash;
+        routeName = opts.route;
 
-    var opts = options && options.hash;
+    } else {
+        opts = options && options.hash;
+    }
 
     opts = opts || {};
 


### PR DESCRIPTION
Hi, there was a small bug in the lookup of the helpers hash aka opts if you use  `pathFor ... data=...`
