### PR TITLE
workaround: autoConfLanguage strictly compared navigator.language with i18n.languages

### DIFF
--- a/lib/router_client.js
+++ b/lib/router_client.js
@@ -76,8 +76,9 @@ Meteor.startup(function () {
 
     if (Router.options.i18n.autoConfLanguage) {
         var lang;
-        if (_.contains(Router.options.i18n.languages, navigator.language)) {
-            lang = navigator.language;
+        var naviLang = navigator.language.slice(0,2);
+        if (_.contains(Router.options.i18n.languages, naviLang)) {
+            lang = naviLang;
         } else {
             lang = Router.getDefaultLanguage();
         }


### PR DESCRIPTION
It is rather raising an issue.

About autoConfLanguage.
The doc suggests that languages are specified by two letters such as 'it', 'es', 'en', but many of navigator.language consist of two letters for language and two letters for country with '-'.
So I changed the detection part to ignore country code.

It is not a good idea, but present autoConfLanguage functionality does not work in almost all cases...
