### PR TITLE
ignores Array.prototype extensions

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -196,7 +196,7 @@ Router.configure = function (options) {
 };
 
 Router._createDeferredRoutes = function () {
-    for (var n in this._i18n.deferredRoutes) {
+    for (var n = 0; n < this._i18n.deferredRoutes.length; n++) {
         var defRoute = this._i18n.deferredRoutes[n];
         defRoute.opts = defRoute.opts || {};
         defRoute.opts.createRoute = true;


### PR DESCRIPTION
Some libraries extend Array.prototype, and they cause an error in Router._createDeferredRoutes loop.
